### PR TITLE
Add support for Mappers 9 and 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ LaiNES implements the most common mappers, which should be enough for a good per
 - CNROM (Mapper 003)
 - MMC3, MMC6 / TxROM (Mapper 004)
 - AxROM (Mapper 007)
+- MMC2 / PxROM (Mapper 009)
+- MMC4 / FxROM (Mapper 010)
 - Color Dreams (Mapper 011)
 - BNROM / NINA-001 (Mapper 034)
 - GxROM (Mapper 066)

--- a/src/cartridge.cpp
+++ b/src/cartridge.cpp
@@ -7,6 +7,8 @@
 #include "mappers/mapper3.hpp"
 #include "mappers/mapper4.hpp"
 #include "mappers/mapper7.hpp"
+#include "mappers/mapper9.hpp"
+#include "mappers/mapper10.hpp"
 #include "mappers/mapper11.hpp"
 #include "mappers/mapper34.hpp"
 #include "mappers/mapper66.hpp"
@@ -71,6 +73,8 @@ void load(const char* fileName)
         case 3:  mapper = new Mapper3(rom); break;
         case 4:  mapper = new Mapper4(rom); break;
         case 7:  mapper = new Mapper7(rom); break;
+        case 9:  mapper = new Mapper9(rom); break;
+        case 10: mapper = new Mapper10(rom); break;
         case 11: mapper = new Mapper11(rom); break;
         case 34: mapper = new Mapper34(rom); break;
         case 66: mapper = new Mapper66(rom); break;

--- a/src/include/mapper.hpp
+++ b/src/include/mapper.hpp
@@ -25,7 +25,7 @@ class Mapper
     u8 read(u16 addr);
     virtual u8 write(u16 addr, u8 v) { return v; }
 
-    u8 chr_read(u16 addr);
+    virtual u8 chr_read(u16 addr);
     virtual u8 chr_write(u16 addr, u8 v) { return v; }
 
     virtual void signal_scanline() {}

--- a/src/include/mappers/mapper10.hpp
+++ b/src/include/mappers/mapper10.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "mapper.hpp"
+
+
+class Mapper10 : public Mapper
+{
+    u8 prg_bank;
+    u8 chr_bank_fd[2];
+    u8 chr_bank_fe[2];
+    u8 chr_latch[2];
+    u8 mirroring;
+
+    void apply();
+
+    public:
+    Mapper10(u8* rom) : Mapper(rom)
+    {
+        prg_bank = 0;
+        chr_bank_fd[0] = chr_bank_fd[1] = 0;
+        chr_bank_fe[0] = chr_bank_fe[1] = 0;
+        chr_latch[0] = chr_latch[1] = 1;  /* Latch states are 0 or 1, start at FE state */
+        mirroring = 0;
+        apply();
+    }
+
+    u8 write(u16 addr, u8 v);
+    u8 chr_read(u16 addr);
+    u8 chr_write(u16 addr, u8 v);
+};

--- a/src/include/mappers/mapper9.hpp
+++ b/src/include/mappers/mapper9.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "mapper.hpp"
+
+
+class Mapper9 : public Mapper
+{
+    u8 prg_bank;
+    u8 chr_bank_fd[2];
+    u8 chr_bank_fe[2];
+    u8 chr_latch[2];
+    u8 mirroring;
+
+    void apply();
+
+    public:
+    Mapper9(u8* rom) : Mapper(rom)
+    {
+        prg_bank = 0;
+        chr_bank_fd[0] = chr_bank_fd[1] = 0;
+        chr_bank_fe[0] = chr_bank_fe[1] = 0;
+        chr_latch[0] = chr_latch[1] = 1;  /* Latch states are 0 or 1, start at FE state */
+        mirroring = 0;
+        apply();
+    }
+
+    u8 write(u16 addr, u8 v);
+    u8 chr_read(u16 addr);
+    u8 chr_write(u16 addr, u8 v);
+};

--- a/src/mappers/mapper10.cpp
+++ b/src/mappers/mapper10.cpp
@@ -1,0 +1,97 @@
+#include "ppu.hpp"
+#include "mappers/mapper10.hpp"
+
+/* MMC4 (FxROM) - Mapper 10 */
+/* Fire Emblem games */
+
+void Mapper10::apply()
+{
+    /* 16KB PRG ROM banking at $8000-$BFFF */
+    map_prg<16>(0, prg_bank);
+
+    /* Fixed last 16KB at $C000-$FFFF */
+    map_prg<16>(1, -1);
+
+    /* CHR ROM banking based on latches (0 = FD, 1 = FE) */
+    u8 chr_bank_0 = (chr_latch[0] == 0) ? chr_bank_fd[0] : chr_bank_fe[0];
+    u8 chr_bank_1 = (chr_latch[1] == 0) ? chr_bank_fd[1] : chr_bank_fe[1];
+
+    map_chr<4>(0, chr_bank_0);
+    map_chr<4>(1, chr_bank_1);
+
+    /* Mirroring */
+    set_mirroring(mirroring ? PPU::HORIZONTAL : PPU::VERTICAL);
+}
+
+u8 Mapper10::write(u16 addr, u8 v)
+{
+    switch (addr & 0xF000)
+    {
+        case 0xA000:  /* PRG ROM bank select */
+            prg_bank = v & 0x0F;
+            apply();
+            break;
+
+        case 0xB000:  /* CHR ROM $FD bank for $0000-$0FFF */
+            chr_bank_fd[0] = v & 0x1F;
+            apply();
+            break;
+
+        case 0xC000:  /* CHR ROM $FE bank for $0000-$0FFF */
+            chr_bank_fe[0] = v & 0x1F;
+            apply();
+            break;
+
+        case 0xD000:  /* CHR ROM $FD bank for $1000-$1FFF */
+            chr_bank_fd[1] = v & 0x1F;
+            apply();
+            break;
+
+        case 0xE000:  /* CHR ROM $FE bank for $1000-$1FFF */
+            chr_bank_fe[1] = v & 0x1F;
+            apply();
+            break;
+
+        case 0xF000:  /* Mirroring */
+            mirroring = v & 0x01;
+            apply();
+            break;
+    }
+    return v;
+}
+
+u8 Mapper10::chr_read(u16 addr)
+{
+    u8 value = chr[chrMap[addr / 0x400] + (addr % 0x400)];
+
+    /* Check for latch triggers AFTER the read - MMC4 uses ranges for both pattern tables */
+    /* Left pattern table latch (address ranges) */
+    if (addr >= 0x0FD8 && addr <= 0x0FDF)
+    {
+        chr_latch[0] = 0;  /* Set latch to FD state */
+        apply();
+    }
+    else if (addr >= 0x0FE8 && addr <= 0x0FEF)
+    {
+        chr_latch[0] = 1;  /* Set latch to FE state */
+        apply();
+    }
+    /* Right pattern table latch (address ranges) */
+    else if (addr >= 0x1FD8 && addr <= 0x1FDF)
+    {
+        chr_latch[1] = 0;  /* Set latch to FD state */
+        apply();
+    }
+    else if (addr >= 0x1FE8 && addr <= 0x1FEF)
+    {
+        chr_latch[1] = 1;  /* Set latch to FE state */
+        apply();
+    }
+
+    return value;
+}
+
+u8 Mapper10::chr_write(u16 addr, u8 v)
+{
+    return chr[addr] = v;
+}

--- a/src/mappers/mapper9.cpp
+++ b/src/mappers/mapper9.cpp
@@ -1,0 +1,99 @@
+#include "ppu.hpp"
+#include "mappers/mapper9.hpp"
+
+/* MMC2 (PxROM) - Mapper 9 */
+/* Used by Mike Tyson's Punch-Out!! */
+
+void Mapper9::apply()
+{
+    /* 8KB PRG ROM banking at $8000-$9FFF */
+    map_prg<8>(0, prg_bank);
+
+    /* Fixed last 24KB at $A000-$FFFF */
+    map_prg<8>(1, -3);
+    map_prg<8>(2, -2);
+    map_prg<8>(3, -1);
+
+    /* CHR ROM banking based on latches (0 = FD, 1 = FE) */
+    u8 chr_bank_0 = (chr_latch[0] == 0) ? chr_bank_fd[0] : chr_bank_fe[0];
+    u8 chr_bank_1 = (chr_latch[1] == 0) ? chr_bank_fd[1] : chr_bank_fe[1];
+
+    map_chr<4>(0, chr_bank_0);
+    map_chr<4>(1, chr_bank_1);
+
+    /* Mirroring */
+    set_mirroring(mirroring ? PPU::HORIZONTAL : PPU::VERTICAL);
+}
+
+u8 Mapper9::write(u16 addr, u8 v)
+{
+    switch (addr & 0xF000)
+    {
+        case 0xA000:  /* PRG ROM bank select */
+            prg_bank = v & 0x0F;
+            apply();
+            break;
+
+        case 0xB000:  /* CHR ROM $FD bank for $0000-$0FFF */
+            chr_bank_fd[0] = v & 0x1F;
+            apply();
+            break;
+
+        case 0xC000:  /* CHR ROM $FE bank for $0000-$0FFF */
+            chr_bank_fe[0] = v & 0x1F;
+            apply();
+            break;
+
+        case 0xD000:  /* CHR ROM $FD bank for $1000-$1FFF */
+            chr_bank_fd[1] = v & 0x1F;
+            apply();
+            break;
+
+        case 0xE000:  /* CHR ROM $FE bank for $1000-$1FFF */
+            chr_bank_fe[1] = v & 0x1F;
+            apply();
+            break;
+
+        case 0xF000:  /* Mirroring */
+            mirroring = v & 0x01;
+            apply();
+            break;
+    }
+    return v;
+}
+
+u8 Mapper9::chr_read(u16 addr)
+{
+    u8 value = chr[chrMap[addr / 0x400] + (addr % 0x400)];
+
+    /* Check for latch triggers AFTER the read */
+    /* Left pattern table latch (only specific addresses) */
+    if (addr == 0x0FD8)
+    {
+        chr_latch[0] = 0;  /* Set latch to FD state */
+        apply();
+    }
+    else if (addr == 0x0FE8)
+    {
+        chr_latch[0] = 1;  /* Set latch to FE state */
+        apply();
+    }
+    /* Right pattern table latch (address ranges) */
+    else if (addr >= 0x1FD8 && addr <= 0x1FDF)
+    {
+        chr_latch[1] = 0;  /* Set latch to FD state */
+        apply();
+    }
+    else if (addr >= 0x1FE8 && addr <= 0x1FEF)
+    {
+        chr_latch[1] = 1;  /* Set latch to FE state */
+        apply();
+    }
+
+    return value;
+}
+
+u8 Mapper9::chr_write(u16 addr, u8 v)
+{
+    return chr[addr] = v;
+}


### PR DESCRIPTION
Added support for Mappers 9 and 10 (MMC2 and MMC)

Tested with actual game(s) and HolyMackerl test roms. Added ability for mappers to override CHR reads